### PR TITLE
Remove unused code and comments from pre-types implementation 

### DIFF
--- a/FriedVM/FBinary.cpp
+++ b/FriedVM/FBinary.cpp
@@ -118,24 +118,7 @@ varible* FBinary::GetParams(INSTRUCTION& instruction)
 
 	return params;
 }
-//uint32_t* FBinary::GetParams(INSTRUCTION &instruction)
-//{
-//	if (instruction.paramCount > maxParamCount)
-//	{
-//		DIE << "Amount of paramters requested exeeds the max amount of parameters defined!";
-//		return NULL;
-//	}
-//
-//	uint32_t *params = new uint32_t[instruction.paramCount];
-//	for (int i = 0; i < instruction.paramCount; i++)
-//	{
-//		//auto bytes = ReadBytes(instruction.arg_size);
-//		//params[i] = CastToUint32(bytes, instruction.arg_size);
-//		params[i] = (uint32_t)VLQ();
-//	}
-//
-//	return params;
-//}
+
 uint64_t FBinary::offsetted_VLQ(uint64_t* offset)
 {
 	uint64_t value = 0;
@@ -157,65 +140,13 @@ uint64_t FBinary::offsetted_VLQ(uint64_t* offset)
 
 	return value;
 }
-//uint64_t FBinary::offsetted_VLQ(ValueType type) 
-//{
-//	for (size_t i = 0; i < size; i++)
-//	{
-//		buffer[i] = instance.bytecode[pos + i];
-//	}
-//	uint64_t value = 0;
-//	uint8_t shift = 0;
-//	uint8_t byte = 0;
-//
-//	do
-//	{
-//		byte = GetByte();
-//		value |= (uint64_t)(byte & 0x7F) << shift; // Mask out MSB and shift
-//		shift += 7;
-//
-//		if (shift >= 64) // Prevent overflow
-//		{
-//			DIE << "VLQ decoding error: shift exceeded 64 bits, possibly malformed data.";
-//		}
-//
-//	} while (byte & 0x80); // Continue if MSB is 1
-//
-//	return value;
-//}
+
 void FBinary::getVaribleTypeSize(uint64_t* position, varible varible)
 {
 	uint64_t value = offsetted_VLQ(position);
 	delete varible->data;
 	varible->data = CastFromUint64(value, varible->length);
-	//uint8_t byte = 0;
 
-	////varible->length = size;
-	//uint8_t* buffer = varible->data;
-	//auto size = varible->length;
-
-	//size_t i = 0;
-	//do
-	//{
-	//	byte = GetByte(position);
-	//	buffer[i] = byte & 0x7F;
-	//	i++;
-
-	//	if (i >= size) // Prevent overflow
-	//	{
-	//		DIE << "VLQ decoding error: shift exceeded 64 bits, possibly malformed data.";
-	//	}
-
-	//} while (byte & 0x80); // Continue if MSB is 1
-
-	////pad the ramaining with 0
-	//for (; i < size; i++)
-	//{
-	//	buffer[i] = pad;
-	//	*position += 1;
-	//}
-
-	////delete[] varible->data;
-	////varible->data = buffer;
 }
 uint64_t FBinary::getComplexTypeSize(ValueType type, uint64_t *position) {
 	switch (type) {
@@ -272,20 +203,7 @@ void FBinary::FillData(uint64_t *position, varible varible)
 		}
 	}
 
-	//auto position = totalLength + constPoolStart;
-	//totalLength += size;
 
-	//for (size_t i = 0; i < length; i++)
-	//{
-	//	if (i > newVarible->length)
-	//	{
-	//		buffer[i] = instance.bytecode[position + i];
-	//	}
-	//	else
-	//	{
-	//		buffer[i] = newVarible->data[i];
-	//	}
-	//}
 
 
 }
@@ -301,49 +219,13 @@ varible FBinary::ParseTypeByte(std::vector<uint8_t> &complex_buffer, bool canBeC
 	bool isConst = ((byte & vt_constant_flag_mask) != 0);
 	ValueType type_byte = static_cast<ValueType>(byte & ~vt_constant_flag_mask);
 
-	//if (type_byte == vt_constant)
-	//{
-	//	varible val = ParseTypeByte(complex_buffer);
-	//	val->isConst = true;
-	//	return val;
-	//}
-	//else if (type_byte == vt_string)
-	//{
-	//	return BaseValue::createValue(type_byte);
-	//}
-	//else if (type_byte == vt_array)
-	//{ //only if vt_complex_type using make_type
-	//	//length vlq
-	//	uint8_t byte;
-	//	do
-	//	{
-	//		byte = GetByte();
-	//		complex_buffer.push_back(byte);
-	//	}
-	//	while (byte & 0x80);
-	//	ParseTypeByte(complex_buffer);
-	//}
-	//else
+
 	{
 		varible val = BaseValue::createValue(type_byte);
 		val->isConst = isConst;
 		return val;
 	}
-	//if (IsComplexType(type_byte))
-	//{
-	//}
-	//else
-	//{
-	//	BaseValue::getTypeSize(type_byte);
-	//}
-	//return type_byte;
-	//for (uint8_t i = 0; i < count; i++)
-	//{
-	//	buffer[i] = instance.bytecode[instance.pc + i];
-	//}
-	//instance.pc += count;
-	//return buffer;
-	//return CastToUint64(ReadBytes(instance.meta_size), instance.meta_size);
+
 }
 bool FBinary::IsComplexType(ValueType vt)
 {

--- a/FriedVM/InstructionSet.h
+++ b/FriedVM/InstructionSet.h
@@ -25,7 +25,7 @@ public:
 	const uint8_t opcode;
 	const std::string op_name;
 	const uint8_t paramCount;
-	//uint8_t arg_size; // Argument size (0–3)
+	//uint8_t arg_size; // Argument size (0ï¿½3)
 	//bool immediate;   // Immediate flag
 	//std::function<void(uint32_t* params, bool immediate, uint8_t arg_size)> execute;
 	std::function<bool(varible *params)> execute;
@@ -91,14 +91,7 @@ public:
 #define iGET_STRUCT		0xBB
 #define iCREATE_STRUCT  0xBC
 
-//#define i			0x18
-//#define i			0x19
-//#define i			0x1A
-//#define i			0x1B
-//#define i			0x1C
-//#define i			0x1D
-//#define i			0x1E
-//#define i			0x1F
+
 
 
 //math Modes
@@ -127,7 +120,7 @@ public:
 #define bmPUSH_FROM_STACK	0x02
 #define bmREMOVE_FROM_END	0x03
 #define bmFORMAT			0x04
-//#define bm					0x05
+
 
 #define iTRUE		0x01
 #define iFALSE		0x00

--- a/FriedVM/Types/BaseValue.cpp
+++ b/FriedVM/Types/BaseValue.cpp
@@ -126,36 +126,3 @@ bool BaseValue::isTruthy() const {
     }
 }
 
-//// The main Add method to dispatch based on type
-//template <typename Func>
-//BaseValue BaseValue::ExecuteTyped(Func func,const BaseValue& v1, const BaseValue& v2) {
-//    // Validate if both values are numbers
-//    if (!v1.isNumber() || !v2.isNumber()) {
-//        DIE << "Cannot add non-number values";
-//    }
-//    //if (v1.type_index != v2.type_index || v1.length != v2.length) {
-//    //    // Cast v2 to the same type as v1
-//    //    BaseValue casted = v2.Cast(v1.type_index);
-//    //    return Add(v1, casted);  // Now they are both of the same type
-//    //}
-//
-//    BaseValue result(v1.type_index, v1.length);
-//
-//    // Dispatch based on type
-//    switch (v1.type_index) {
-//    case vt_uint8_t:   result = func<uint8_t>(v1, v2); break;
-//    case vt_uint16_t:  result = func<uint16_t>(v1, v2); break;
-//    case vt_uint32_t:  result = func<uint32_t>(v1, v2); break;
-//    case vt_uint64_t:  result = func<uint64_t>(v1, v2); break;
-//    case vt_int8_t:    result = func<int8_t>(v1, v2); break;
-//    case vt_int16_t:   result = func<int16_t>(v1, v2); break;
-//    case vt_int32_t:   result = func<int32_t>(v1, v2); break;
-//    case vt_int64_t:   result = func<int64_t>(v1, v2); break;
-//    case vt_float_t:   result = func<float>(v1, v2); break;
-//    case vt_double_t:  result = func<double>(v1, v2); break;
-//    default:
-//        DIE << "Unsupported type in Add";
-//    }
-//
-//    return result;
-//}

--- a/FriedVM/Types/BaseValue.h
+++ b/FriedVM/Types/BaseValue.h
@@ -138,21 +138,7 @@ struct BaseValue
         default:
             DIE << "Unsupported type in getValue";
         }
-        //if (value->length != sizeof(T))
-        //{
-        //    DIE << "Templated type does not match the underlying datatype";
-        //    //instead of this error it should somehow make it work
-        //    //if this is the data we request, itll just pad it out to make it work?
-        //    //T is the type we want
-        //    //value->data is the data that needs to be made to work with T
-        //    //value->type_index is an enum representing the datatype
-        //}
 
-        //// Create a temporary variable to store the value
-        //T result;
-        //// Safely copy the data into the result variable
-        //std::memcpy(&result, value->data, sizeof(T));
-        //return result;
     }
 
     static BaseValue* dupValue(const BaseValue* value) {
@@ -162,30 +148,7 @@ struct BaseValue
         return val;
     }
 
-    //// Static factory methods for creating BaseValue instances
-    //static BaseValue makeRaw(uint8_t* data, size_t len) {
-    //    BaseValue val(vt_raw, len);
-    //    std::memcpy(val.data, data, len);  // Copy the raw data
-    //    return val;
-    //}
 
-    //static BaseValue makeNumber(ValueType t, void* value) {
-    //    BaseValue val(t, 1); // Only one element (a single number)
-    //    std::memcpy(val.data, value, getTypeSize(t));  // Copy the value
-    //    return val;
-    //}
-
-    //static BaseValue makeArray(ValueType t, void* arr, size_t len) {
-    //    BaseValue val(t, len);
-    //    std::memcpy(val.data, arr, len * getTypeSize(t));  // Copy the array data
-    //    val.isArray = true;  // Set the isArray flag
-    //    return val;
-    //}
-
-    //// Helper methods to manipulate the union members (isArray & type_index)
-    //void setIsArray(bool isArrayFlag) {
-    //    isArray = isArrayFlag;
-    //}
 
     void setTypeIndex(ValueType type) {
         type_index = type;
@@ -364,123 +327,14 @@ struct BaseValue
         return BaseValue::computeNumbers(val, input, BaseValue::AddOperation{});
     }
 
-    //struct RNDOperation {
-    //    template <typename T1, typename T2>
-    //    BaseValue* operator()(ValueType ret_type, T1 a, T2 b) const {
-    //        using std::is_integral;
-    //        using R = decltype(a + b); // promote types if needed
-
-    //        R result;
-
-    //        if constexpr (is_integral<T1>::value && is_integral<T2>::value) {
-    //            // integer version
-    //            result = static_cast<R>(rand() % (b - a + 1) + a); // inclusive
-    //        }
-    //        else {
-    //            // floating point version
-    //            double da = static_cast<double>(a);
-    //            double db = static_cast<double>(b);
-    //            result = static_cast<R>(da + (db - da) * (rand() / (RAND_MAX + 1.0)));
-    //        }
-
-    //        return makeValue(ret_type, result);
-    //    }
-    //};
-
-    //// Cast function to convert BaseValue to a different type
-    //BaseValue Cast(ValueType targetType) const {
-    //    // Create a new BaseValue to store the casted result
-    //    BaseValue casted(targetType, length);
-
-    //    size_t targetTypeSize = getTypeSize(targetType);
-    //    size_t currentTypeSize = getTypeSize(type_index);
-
-    //    if (targetType == type_index) {
-    //        std::memcpy(casted.data, data, length * currentTypeSize);  // Direct copy if types match
-    //        return casted;
-    //    }
-
-    //    if (type_index == vt_raw || targetType == vt_raw) {
-    //        // Handle raw data cases, typically byte-to-byte copy
-    //        std::memcpy(casted.data, data, length * currentTypeSize);
-    //        return casted;
-    //    }
-
-    //    // Handle casting between numeric types
-    //    if (isNumber() && targetType != vt_raw) {
-    //        size_t newLength = length * targetTypeSize / currentTypeSize;
-
-    //        if (newLength != length) {
-    //            // If new length doesn't match, resize or truncate
-    //            std::memcpy(casted.data, data, newLength * targetTypeSize);
-    //        }
-    //        else {
-    //            std::memcpy(casted.data, data, length * targetTypeSize);
-    //        }
-    //        return casted;
-    //    }
-
-    //    // Handling for other types (such as float-to-double or integer-to-float)
-    //    if ((type_index == vt_float_t && targetType == vt_double_t) ||
-    //        (type_index == vt_double_t && targetType == vt_float_t)) {
-    //        // Example: Adjusting precision for float to double (or vice versa)
-    //        std::memcpy(casted.data, data, length * targetTypeSize);
-    //        return casted;
-    //    }
-
-    //    // If not handled, throw an exception
-    //    throw std::runtime_error("Unsupported casting between types");
-    //}
-    // Template function for adding two BaseValue instances
-    //template<typename T>
-    //static BaseValue* HandleTyped(const BaseValue& v1, const BaseValue& v2, std::function<T(T,T)> operation) {
-    //    // Ensure the size of T matches the type size of v1
-    //    if (sizeof(T) != getTypeSize(v1.type_index)) {
-    //        DIE << "Size mismatch between T and BaseValue type";
-    //    }
-
-    //    // Now, we assume the data in v1 and v2 is of the correct length and type
-    //    // Cast the data from uint8_t* to T* (the target type, e.g., uint32_t*)
-    //    T* data1 = reinterpret_cast<T*>(v1.data);
-    //    T* data2 = nullptr;
-    //    T temp;  // keeps the converted value alive
-
-    //    if (v1.type_index == v2.type_index)
-    //    {
-    //        data2 = reinterpret_cast<T*>(v2.data);
-    //    }
-    //    else
-    //    {
-    //        temp = BaseValue::getValue<T>(&v2); // copy into a safe owned place
-    //        data2 = &temp;
-    //    }
 
 
 
-    //    // Perform the addition
-    //    T result = operation(*data1, *data2);
-
-    //    return makeValue<T>(v1.type_index, result);
-    //    //return new BaseValue<T>(v1.type_index, result);
-    //    //BaseValue *blah = makeValue<T>(v1.type_index, result);
-
-    //    //return blah;
-    //    //// Create a new BaseValue to store the result
-    //    //BaseValue resultVal(v1.type_index, 1);  // Only one element in the result
-    //    //std::memcpy(resultVal.data, &result, sizeof(T));  // Copy the result back into the data
-
-    //    //return resultVal;
-    //}
 
 
 
-    //template<typename T>
-    //static BaseValue AddTyped(const BaseValue& v1, const BaseValue& v2)
-    //{
-    //    return HandleTyped<T>(v1, v2, [](T a, T b) {
-    //        return a + b;
-    //    });
-    //}
+
+
     static void ParseString(const BaseValue* var1, BaseValue* result)
     {
         if (var1->type_index != vt_string)
@@ -649,24 +503,7 @@ struct BaseValue
         return true;
     }
 
-    //template<typename T>
-    //static bool try_parse(const std::string& str, T& out) {
-    //    auto* begin = str.data();
-    //    auto* end = str.data() + str.size();
 
-    //    if constexpr (std::is_integral_v<T>) {
-    //        auto [ptr, ec] = std::from_chars(begin, end, out);
-    //        return (ec == std::errc{} && ptr == end);
-    //    }
-    //    else if constexpr (std::is_floating_point_v<T>) {
-    //        // from_chars for float/double only guaranteed in C++17+
-    //        auto [ptr, ec] = std::from_chars(begin, end, out);
-    //        return (ec == std::errc{} && ptr == end);
-    //    }
-    //    else {
-    //        static_assert(!sizeof(T*), "try_parse: unsupported type");
-    //    }
-    //}
 
     static BaseValue* ToString(const BaseValue* var1) 
     {
@@ -733,108 +570,9 @@ struct BaseValue
         return result;
     }
 
-    ////BaseValue ExecuteTyped(Func func, const BaseValue& v1, const BaseValue& v2);
-    //template <typename Func>
-    //static BaseValue* ExecuteTyped(Func func, const BaseValue* v1, const BaseValue* v2){ //, BaseValue* result) {
-    //    if (!v1 || !v2) {
-    //        DIE << "Null pointer passed to ExecuteTyped";
-    //        //return nullptr;
-    //    }
 
 
-    //    // Dispatch based on type
-    //    switch (v1->type_index) {
-    //    case vt_uint8_t:   return func.template operator()<uint8_t>(v1, v2); break;
-    //    case vt_uint16_t:  return func.template operator()<uint16_t>(v1, v2); break;
-    //    case vt_uint32_t:  return func.template operator()<uint32_t>(v1, v2); break;
-    //    case vt_uint64_t:  return func.template operator()<uint64_t>(v1, v2); break;
-    //    case vt_int8_t:    return func.template operator()<int8_t>(v1, v2); break;
-    //    case vt_int16_t:   return func.template operator()<int16_t>(v1, v2); break;
-    //    case vt_int32_t:   return func.template operator()<int32_t>(v1, v2); break;
-    //    case vt_int64_t:   return func.template operator()<int64_t>(v1, v2); break;
-    //    case vt_float_t:   return func.template operator()<float>(v1, v2); break;
-    //    case vt_double_t:  return func.template operator()<double>(v1, v2); break;
-    //    default:
-    //        DIE << "Unsupported type in ExecuteTyped";
-    //    }
 
-    //    return nullptr;
-    //}
-
-    //static struct AddTypedFunctor {
-    //    template <typename T>
-    //    BaseValue* operator()(const BaseValue* v1, const BaseValue* v2) const {
-    //        return HandleTyped<T>(*v1, *v2, [](T a, T b) {
-    //            return a + b;
-    //            });
-    //    }
-    //};
-    //static struct SubTypedFunctor {
-    //    template <typename T>
-    //    BaseValue* operator()(const BaseValue* v1, const BaseValue* v2) const {
-    //        return HandleTyped<T>(*v1, *v2, [](T a, T b) {
-    //            return a - b;
-    //            });
-    //    }
-    //};
-    //static struct MulTypedFunctor {
-    //    template <typename T>
-    //    BaseValue* operator()(const BaseValue* v1, const BaseValue* v2) const {
-    //        return HandleTyped<T>(*v1, *v2, [](T a, T b) {
-    //            return a * b;
-    //            });
-    //    }
-    //};
-    //static struct DivTypedFunctor {
-    //    template <typename T>
-    //    BaseValue* operator()(const BaseValue* v1, const BaseValue* v2) const {
-    //        return HandleTyped<T>(*v1, *v2, [](T a, T b) {
-    //            return a / b;
-    //            });
-    //    }
-    //};
-    //static struct AndTypedFunctor {
-    //    template <typename T>
-    //    BaseValue* operator()(const BaseValue* v1, const BaseValue* v2) const {
-    //        return HandleTyped<T>(*v1, *v2, [](T a, T b) {
-    //            return a & b;
-    //            });
-    //    }
-    //};
-    //static struct OrTypedFunctor {
-    //    template <typename T>
-    //    BaseValue* operator()(const BaseValue* v1, const BaseValue* v2) const {
-    //        return HandleTyped<T>(*v1, *v2, [](T a, T b) {
-    //            return a | b;
-    //        });
-    //    }
-    //};
-    //static struct RndTypedFunctor {
-    //    mutable uint64_t seed = 0xDEADBABE12345678; // you can make it settable if u want :)
-
-    //    template <typename T>
-    //    BaseValue* operator()(const BaseValue* v1, const BaseValue* v2) const {
-    //        return BaseValue::HandleTyped<T>(*v1, *v2, [this](T a, T b) -> T {
-    //            if (a > b) std::swap(a, b);
-
-    //            // === custom LCG RNG ===
-    //            seed = seed * 6364136223846793005ULL + 1;
-    //            uint64_t randVal = (seed >> 16) & 0xFFFFFFFF;
-
-    //            if constexpr (std::is_integral_v<T>) {
-    //                T range = b - a + 1;
-    //                return a + (randVal % range);
-    //            }
-    //            else if constexpr (std::is_floating_point_v<T>) {
-    //                double norm = static_cast<double>(randVal) / static_cast<double>(0xFFFFFFFF);
-    //                return static_cast<T>(a + norm * (b - a));
-    //            }
-    //            else {
-    //                DIE << "Unsupported type in RndTypedFunctor";
-    //            }
-    //            });
-    //    }
-    //};
 
 
 };

--- a/FriedVM/VMCore.cpp
+++ b/FriedVM/VMCore.cpp
@@ -1,59 +1,9 @@
 #include "VMCore.h"
-#include <thread>
-#include <random>
-#include <chrono>
 
 void VMCore::Parse()
 {
-	//float value = 0;
-	//varible var1 = BaseValue::makeValue(vt_float_t, value);
-
-
-	//std::string text = "10.5";
-	//varible str = BaseValue::makeString(text);
-
-	//BaseValue::ParseString(str, var1);
-
-	//float output = safe_cast<float>(var1);
-
-	/////	declare float converted;
-	/////	push converted
-	///// push string "10.5" //or from user input
-	///// syscall parse
-
-	//// converted is now 10.5
-	//// if our input string was "bad input" or not a number
-	//// then it would not convert and converted would just not be set
-	//// so if u want default value then just initialize converted to whatever value u want as fallback
-
-
-	//float value = 20.0;
-	//varible var1 = BaseValue::makeValue(vt_float_t, value);
-
-
-	//uint8_t value2 = 20;
-	//varible var2 = BaseValue::makeValue(vt_uint8_t, value2);
-
-
-	//varible var3 = BaseValue::EQCompareNumbers(var1, var2);
-	//bool value3 = safe_cast<bool>(var3);
-	//auto vlqresult = binaryApi.VLQ();
-
-
-	//uint32_t value = 50;
-	//varible var1 = BaseValue::makeValue(vt_uint32_t, value);
-	//
-	//uint32_t value2 = 20;
-	//varible var2 = BaseValue::makeValue(vt_uint32_t, value2);
-	//
-	//varible result = BaseValue::ExecuteTyped(BaseValue::SubTypedFunctor(), var1, var2);
-	////auto result = BaseValue::ExecuteTyped(BaseValue::AddTyped, var1, var2);
-	//
-	//uint32_t castedResult = BaseValue::getValue<uint32_t>(result);
-
-
 	binaryApi.ParseMagic();
-	//uint64_t emptyVarCount = binaryApi.ParseEmptyVarCount();
+
 	instance.instructionStart = binaryApi.ParseAddress();
 	instance.constPoolStart = binaryApi.ParseAddress();
 	uint64_t symbolsStart = 0;
@@ -120,25 +70,7 @@ void VMCore::Parse()
 		{
 			varible newVarible = BaseValue::dupValue(var_type);
 			binaryApi.FillData(&totalLength, newVarible);
-			/*size_t size = BaseValue::getTypeSize(newVarible->type_index);
-			totalLength += size;
-
-			auto length = newVarible->length + size;
-			uint8_t *buffer = new uint8_t[length];
-			for (size_t i = 0; i < length; i++)
-			{
-				if (i > newVarible->length)
-				{
-					buffer[i] = instance.bytecode[position + i];
-				}
-				else
-				{
-					buffer[i] = newVarible->data[i];
-				}
-			}
-
-			delete[] newVarible->data;
-			newVarible->data = buffer;*/
+	
 			instance.typed_varibles.push_back(newVarible);
 			newVarible->rest = instance.typed_varibles.size();
 		}
@@ -164,28 +96,10 @@ void VMCore::Parse()
 			delete newDefaultVarible;
 		}
 		delete var_type;
-		////uint8_t type_byte = 
 
-		//if (instance.bytecode.size() < (position + length))
-		//{
-		//	DIE << "file size was too small (" << NUM(instance.bytecode.size()) << "), expected more bytes (" << NUM(position + length) << ")";
-		//}
-		//uint8_t *buffer = new uint8_t[length];
-		//for (size_t i = 0; i < length; i++)
-		//{
-		//	buffer[i] = instance.bytecode[position + i];
-		//}
-
-		//instance.meta.push_back(length);
-		//instance.varibles.push_back(buffer);
-		//instance.declare_size++;
 	}
 	instance.declare_size--; //size not count
-	//for (uint64_t i = 0; i < emptyVarCount; i++) //allocate room for empty varibles
-	//{
-	//	instance.meta.push_back(0);
-	//	instance.varibles.push_back(nullptr);
-	//}
+
 	if (instance.hasSymbols && instance.pc == instance.instructionStart) //symbol section
 	{
 		std::string constFalseSymbol = "false";
@@ -295,71 +209,45 @@ void VMCore::Run(uint64_t start, uint64_t end)
 	}
 
 
-	bool fast = false;
-	
-	if (fast)
+	std::vector<varible> execParams;
+	execParams.reserve(maxParamCount);
+
+	while (instance.ProgramIndex < Statements.size())
 	{
-		while (instance.ProgramIndex < Statements.size())
-		{
-			auto& statement = Statements[instance.ProgramIndex];
+		auto& statement = Statements[instance.ProgramIndex];
 
-			bool advanceProgramIndex = statement.Instruction.execute(statement.params);
+		bool hasInterpolated = false;
 
+		// first check if any param is interpolated
+		for (size_t i = 0; i < statement.Instruction.paramCount; ++i) {
+			if (statement.params[i]->type_index == vt_interpolated_string) {
+				hasInterpolated = true;
+				break;
+			}
+		}
+
+		if (hasInterpolated) {
+			execParams.clear(); // reuse vector
+			for (size_t i = 0; i < statement.Instruction.paramCount; ++i) {
+				auto& p = statement.params[i];
+				if (p->type_index == vt_interpolated_string) {
+					execParams.push_back(resolveInterpolated(p)); // returns a BaseValue* or varible
+				}
+				else {
+					execParams.push_back(p);
+				}
+			}
+			bool advanceProgramIndex = statement.Instruction.execute(execParams.data());
 			if (advanceProgramIndex)
 				instance.ProgramIndex++;
 		}
-		return;
-	}
-	else
-	{
-		std::vector<varible> execParams;
-		execParams.reserve(maxParamCount);
-
-		while (instance.ProgramIndex < Statements.size())
-		{
-			auto& statement = Statements[instance.ProgramIndex];
-
-			bool hasInterpolated = false;
-
-			// first check if any param is interpolated
-			for (size_t i = 0; i < statement.Instruction.paramCount; ++i) {
-				if (statement.params[i]->type_index == vt_interpolated_string) {
-					hasInterpolated = true;
-					break;
-				}
-			}
-
-			if (hasInterpolated) {
-				execParams.clear(); // reuse vector
-				for (size_t i = 0; i < statement.Instruction.paramCount; ++i) {
-					auto& p = statement.params[i];
-					if (p->type_index == vt_interpolated_string) {
-						execParams.push_back(resolveInterpolated(p)); // returns a BaseValue* or varible
-					}
-					else {
-						execParams.push_back(p);
-					}
-				}
-				bool advanceProgramIndex = statement.Instruction.execute(execParams.data());
-				if (advanceProgramIndex)
-					instance.ProgramIndex++;
-			}
-			else {
-				bool advanceProgramIndex = statement.Instruction.execute(statement.params);
-				if (advanceProgramIndex)
-					instance.ProgramIndex++;
-			}
+		else {
+			bool advanceProgramIndex = statement.Instruction.execute(statement.params);
+			if (advanceProgramIndex)
+				instance.ProgramIndex++;
 		}
 	}
-	//instance.ProgramIndex = -1;
-	//while (instance.ProgramIndex < Statements.size())
-	//{
-	//	instance.ProgramIndex++;
-	//	//do bounds check or something
-	//	auto& statement = Statements[instance.ProgramIndex];
 
-	//	statement.Instruction.execute(statement.params);
-	//}
 }
 
 static uint64_t GetVarVLQ(varible var, uint64_t *offset)
@@ -399,18 +287,7 @@ bool VMCore::typed_Peek_stack(varible *output, int offset)
 		return true;
 	}
 }
-bool VMCore::Peek_stack(uint32_t *pValue, int offset)
-{
-	if (instance.sp == 0)
-	{
-		return false;
-	}
-	else
-	{
-		*pValue = instance.stack.at(instance.sp-1);
-		return true;
-	}
-}
+
 bool VMCore::typed_StackTruthy()
 {
 	varible stack_value;
@@ -426,30 +303,7 @@ bool VMCore::typed_StackEquals(varible param_value)
 
 	return BaseValue::Equals(stack_value, param_value);
 }
-bool VMCore::StackEquals(Value &param_value)
-{
-	bool success = false;
-	uint32_t stck_value = 0;
 
-	bool stck_immediate = false;
-	uint8_t stck_arg_size = 0;
-	success |= Peek_stack(&stck_value);
-	success |= getStackType(&stck_immediate, &stck_arg_size);
-	if (success)
-	{
-		Value stack_value = makeValue(stck_value, stck_immediate, stck_arg_size);
-		if (stack_value.length != param_value.length)
-			return false;
-
-		for (uint32_t i = 0; i < stack_value.length; i++)
-		{
-			if (stack_value.data[i] != param_value.data[i])
-				return false;
-		}
-		return true;
-	}
-	return false;
-}
 
 template<typename T>
 T VMCore::safe_cast(varible var)
@@ -467,7 +321,7 @@ varible VMCore::resolveInterpolated(varible interpolated_string)
 	composition.reserve(8); // avoid reallocs, tweak as needed
 
 	uint64_t offset = 0;
-	//auto amount = GetVarVLQ(interpolated_string, &offset);
+
 
 	uint64_t totalSize = 0;
 	while (offset < interpolated_string->length) //while there are still vlq's left to read
@@ -498,37 +352,15 @@ varible VMCore::resolveInterpolated(varible interpolated_string)
 		{
 			output.append(var->toString());
 		}
-		// Assuming var->data is a uint8_t* with string content
+
 	}
 
-	//if (bake)
-	//{
-	//	interpolated_string->type_index = vt_string;
-	//	interpolated_string->length = output.length();
 
-	//	//delete[] interpolated_string->data;
-	//	std::memcpy(interpolated_string->data, output.data(), output.length()); // Copy the raw data
-	//}
 
 	// Return a new runtime string variable
 	return BaseValue::makeString(output);
 
-	//stringstr
-	////uint8_t *data = new uint8_t[size];
-	//for (auto& var : composition)
-	//{
-	//	//memcopy var.data to data but then all behind eachother
-	//	//
-	//	var->data
-	//}
-	//for (size_t i = 0; i < amount; i++)
-	//{
-	//	auto index = GetVarVLQ(interpolated_string, &offset);
-	//	varible var = instance.typed_varibles.at(index);
-	//	size += var->length;
-	//	composition.push_back(var);
-	//}
-	//return interpolated_string;
+
 }
 varible VMCore::typed_pop()
 {
@@ -551,227 +383,25 @@ varible VMCore::dup(varible value)
 	return BaseValue::dupValue(value);
 }
 
-void VMCore::freeVarible(uint32_t index)
-{
-	checkVaribleIndex(index);
 
-	instance.meta[index] = 0;
-	if (instance.varibles[index] != nullptr) {
-		delete[] instance.varibles[index];  // Free the previously allocated memory
-		instance.varibles[index] = nullptr;
-	}
-}
-uint32_t VMCore::pop()
-{
-	if (instance.sp == 0)
-	{
-		DIE << "Nothing on the stack to pop! At program index " << NUM(instance.ProgramIndex);
-	}
-	instance.sp--;
-	uint32_t value = instance.stack.at(instance.sp);
-	instance.stack.pop_back();
-	instance.stack_type.pop_back();
-	return value;
-}
-void VMCore::push(uint32_t value, bool immediate, uint8_t arg_size)
-{
-	instance.sp++;
-	instance.stack.push_back(value);
-	instance.stack_type.push_back((immediate << 7) | (arg_size & 0b01111111));
-}
-uint32_t VMCore::buffer_pop()
-{
-	if (instance.varible_buffer.size() == 0)
-		DIE << "Nothing on the buffer to pop! At program index " << NUM(instance.ProgramIndex);
 
-	uint32_t val = instance.varible_buffer.at(instance.varible_buffer.size()-1);
-	instance.varible_buffer.pop_back();
-	return val;
-}
-void VMCore::buffer_push(Value value)
-{
-	instance.varible_buffer.reserve(instance.varible_buffer.size() + value.length); //reserve more space for the buffer to avoid resize
-	for (uint32_t i = 0; i < value.length; i++)
-	{
-		instance.varible_buffer.push_back(value.data[i]);
-	}
-}
+
 void VMCore::syscall(uint32_t index)
 {
 	if (index > syscall_lookup.size())
 		DIE << "Syscall at index "<< NUM(index) << " does not exist!";
 	syscall_lookup.at(index)();
 }
-Value VMCore::makeValue(uint32_t value, bool immediate, uint8_t arg_size)
-{
-	if (immediate)
-	{
-		uint32_t expanded_arg_size = static_cast<uint32_t>(arg_size);
-		uint8_t* data = binaryApi.CastFromUint32(value, expanded_arg_size);
-		return Value(data, expanded_arg_size, true);
-	}
-	else
-	{
-		checkVaribleIndex(value);
-		uint32_t& length = instance.meta.at(value);
-		uint8_t* data = instance.varibles.at(value);
-		return Value(data, length, false, value);
-	}
-}
-void VMCore::checkVaribleIndex(uint32_t index)
-{
-	if (instance.meta.size() <= index)
-		DIE << "Varible with index " << NUM(index) << "(" << HEX(index) << ") does not exist!";
-}
 
-void VMCore::GetStructCache(Value &struct_instance, StructCache *cache)
-{
-	if (struct_instance.length < structIndexByteCount)
-		DIE << "Invalid struct passed (too small for index)";
 
-	uint32_t index = binaryApi.CastToUint32(struct_instance.data, structIndexByteCount);
-	if (instance.structCache.find(index) != instance.structCache.end())
-		*cache = instance.structCache[index];
-	else
-		*cache = CacheStructDefinition(index);
-}
-void VMCore::GetStructFieldDetails(Value &struct_instance, uint32_t field_index, uint32_t *field_offset, uint8_t *field_length)
-{
-	StructCache cache;
-	GetStructCache(struct_instance, &cache);
 
-	if (struct_instance.length < cache.total_size)
-		DIE << "Struct instance was too small";
 
-	if (field_index >= cache.offsets.size())
-		DIE << "Field index out of bounds";
 
-	*field_offset = cache.offsets[field_index];
-	*field_length = cache.lengths[field_index];
-	return;
-}
-StructCache VMCore::CacheStructDefinition(uint32_t index)
-{
-	Value struct_definition = makeValue(index, false, 0); //use the first few byte/index to get the declare/definition
-	const uint8_t struct_offset = 2;
 
-	if (struct_definition.length < struct_offset || struct_definition.data[0] != 0xFF)
-		DIE << "Invalid struct definition";
 
-	uint8_t amount_of_fields = struct_definition.data[1];
 
-	if (struct_definition.length < (amount_of_fields + struct_offset))
-		DIE << "Struct instance is too small";
-
-	StructCache cache;
-	size_t sum = 0;
-	for (uint8_t i = 0; i < amount_of_fields; i++)
-	{
-		uint8_t length = struct_definition.data[struct_offset + i];
-		cache.lengths.push_back(length);
-		cache.offsets.push_back(sum + structIndexByteCount);
-		sum += length;
-	}
-
-	if (struct_definition.length < sum)
-		DIE << "Invalid struct passed, size was too small!";
-
-	cache.total_size = sum + structIndexByteCount;
-	cache.initial_data = new uint8_t[cache.total_size];
-
-	//copy the struct definition address/index as 4 bytes (structIndexByteCount = 4 bytes)
-	uint8_t* index_bytes = binaryApi.CastFromUint32(index, structIndexByteCount);
-	std::copy(index_bytes, index_bytes + structIndexByteCount, cache.initial_data);
-
-	//copy the initial data, wich is at the end of the definition from data_start_index onwards
-	size_t data_start_index = struct_offset + amount_of_fields;
-	std::copy(struct_definition.data + data_start_index, struct_definition.data + struct_definition.length, cache.initial_data + structIndexByteCount);
-
-	instance.structCache[index] = cache;
-	return cache;
-}
-bool VMCore::getStackType(bool *immediate, uint8_t *arg_size)
-{
-	if (instance.sp == 0)
-	{
-		return false;
-	}
-	else
-	{
-		uint8_t type = instance.stack_type.at(instance.sp - 1);
-		bool stck_immediate = (type & 0b10000000) >> 7;
-		uint8_t stck_arg_size = type & 0b01111111;
-
-		*immediate = stck_immediate;
-		*arg_size = stck_arg_size;
-		return true;
-	}
-}
-uint32_t VMCore::makeUint(uint32_t value, bool immediate, uint8_t arg_size)
-{
-	if (immediate)
-	{
-		return value;
-	}
-	else
-	{
-		Value val = makeValue(value, immediate, arg_size);
-		if (val.length > 4)
-			DIE << "Expected a number wich is max 4 bytes, but got " << NUM(val.length) << " bytes instead!";
-
-		uint32_t result = binaryApi.CastToUint32(val.data, val.length);
-		return result;
-	}
-}
-uint32_t VMCore::getUintVar()
-{
-	bool immediate = false;
-	uint8_t arg_size = 0;
-	bool success = getStackType(&immediate, &arg_size);
-	if (!success)
-	{
-		DIE << "Nothing on the stack to pop! At program index " << NUM(instance.ProgramIndex);
-	}
-
-	uint32_t value = pop();
-
-	return makeUint(value, immediate, arg_size);
-}
-Value VMCore::getVar()
-{
-	bool immediate = false;
-	uint8_t arg_size = 0;
-	bool success = getStackType(&immediate, &arg_size);
-	if (!success)
-	{
-		DIE << "Nothing on the stack to pop! At program index " << NUM(instance.ProgramIndex);
-	}
-
-	uint32_t value = pop();
-	return makeValue(value, immediate, arg_size);
-}
-void VMCore::setVar(Value reference, Value newValue) {
-	//when setting something it needs to be a ref not immidate
-	if (reference.immediate) {
-		DIE << "Cant assign value to immidate!";
-	}
-
-	//new value needs to have data or its kind of worthless
-	if (newValue.data == nullptr) {
-		DIE << "Eror trying to assign to value, cant assign nothing to value (for now)";
-	}
-
-	//its a refernce so we can use the index
-	uint32_t index = reference.index;
-	freeVarible(index);
-	instance.varibles[index] = newValue.data; 
-	instance.meta[index] = newValue.length;
-}
 void VMCore::typed_setVar(varible reference, varible newValue) {
-	//when setting something it needs to be a ref not immidate
-	//if (reference.immediate) {
-	//	DIE << "Cant assign value to immidate!";
-	//}
+
 
 	//new value needs to have data or its kind of worthless
 	if (newValue->data == nullptr) {
@@ -785,7 +415,7 @@ void VMCore::typed_setVar(varible reference, varible newValue) {
 
 		// overwrite existing data
 		std::memcpy(reference->data, casted->data, reference->length);
-		//delete casted; // cleanup temporary
+
 		return;
 	}
 
@@ -802,33 +432,7 @@ void VMCore::typed_setVar(varible reference, varible newValue) {
 
 	std::memcpy(reference->data, newValue->data, newValue->length);
 
-	//BaseValue::computeNumbers(val1, val2, BaseValue::AddOperation{})
 
-	////if (newValue->type_index != reference->type_index)
-	////{
-	////	DIE << "cant assing diffrent types or smth idk?";
-	////	//this is pretty string can assing string to raw
-	////	//cant assing uint8 to uint32
-	////	//need better typcompatability system
-	////	//either that or just overwrite it lol
-	////}
-	//reference->type_index = newValue->type_index;
-
-
-	////delete[]
-	////free(reference->data);
-
-
-	//reference->length = newValue->length;
-	////std::memcpy(reference->data, newValue->data, reference->length);
-	//reference->data = newValue->data;
-
-
-	////its a refernce so we can use the index
-	////uint32_t index = reference.index;
-	////freeVarible(index);
-	////instance.varibles[index] = newValue.data;
-	////instance.meta[index] = newValue.length;
 }
 bool VMCore::Compare(uint8_t compMode, varible val1, varible val2)
 {
@@ -865,13 +469,7 @@ void VMCore::Jump(varible offset)
 	uint64_t idx = safe_cast<uint64_t>(offset);
 	instance.ProgramIndex = idx;
 }
-void VMCore::Jump(uint32_t offset, bool immidiate)
-{
-	//if (immediate)
-	//	instance.pc += params[0];
-	//else
-		instance.ProgramIndex = offset;// instance.instructionStart + offset;
-}
+
 void VMCore::Call(varible offset)
 {
 	if (offset->type_index != vt_label)
@@ -889,7 +487,7 @@ void VMCore::Return()
 	instance.ProgramIndex = instance.call_stack.at(instance.call_stack.size()-1);
 	instance.call_stack.pop_back();
 }
-//#define MAKE_EXECUTE(method) [this](uint32_t* params, bool immediate, uint8_t arg_size) { this->method(params, immediate, arg_size); }
+
 #define MAKE_EXECUTE(method) [this](varible* params) { return this->method(params); }
 #define MAKE_SYS_EXECUTE(method) [this]() { this->method(); }
 
@@ -933,38 +531,18 @@ VMCore::VMCore(VMInstance& newInstance) : VMInstanceBase(newInstance), binaryApi
 
 	opcode_lookup[iRET].execute = MAKE_EXECUTE(typed_RET);
 
-
-
-
-	//opcode_lookup[iSET_BUFFER].execute = MAKE_EXECUTE(SET_BUFFER);
-	//opcode_lookup[iPUSH_BUFFER].execute = MAKE_EXECUTE(PUSH_BUFFER);
-	//opcode_lookup[iGET_BUFFER].execute = MAKE_EXECUTE(GET_BUFFER);
-	//opcode_lookup[iBUFFER_UTIL].execute = MAKE_EXECUTE(BUFFER_UTIL);
-	//opcode_lookup[iSET_STRUCT].execute = MAKE_EXECUTE(SET_STRUCT);
-	//opcode_lookup[iGET_STRUCT].execute = MAKE_EXECUTE(GET_STRUCT);
-	//opcode_lookup[iCREATE_STRUCT].execute = MAKE_EXECUTE(CREATE_STRUCT);
-
 #pragma endregion
 #pragma region Syscalls
-	syscall_lookup.push_back(MAKE_SYS_EXECUTE(SYS_PAUSE));
 	syscall_lookup.push_back(MAKE_SYS_EXECUTE(SYS_CLEAR_CONSOLE));
 	syscall_lookup.push_back(MAKE_SYS_EXECUTE(SYS_READ));
 	syscall_lookup.push_back(MAKE_SYS_EXECUTE(SYS_PRINT));
 	syscall_lookup.push_back(MAKE_SYS_EXECUTE(SYS_PRINTLN));
 	syscall_lookup.push_back(MAKE_SYS_EXECUTE(SYS_DUMP));
 
-	//syscall_lookup.push_back(MAKE_SYS_EXECUTE(SYS_TO_STRING_UNSIGNED));
-	syscall_lookup.push_back(MAKE_SYS_EXECUTE(SYS_TO_STRING_SIGNED));
 	syscall_lookup.push_back(MAKE_SYS_EXECUTE(SYS_PARSE));
-	//syscall_lookup.push_back(MAKE_SYS_EXECUTE(SYS_TO_NUMBER_UNSIGNED));
-	syscall_lookup.push_back(MAKE_SYS_EXECUTE(SYS_TO_NUMBER_SIGNED));
 
 	syscall_lookup.push_back(MAKE_SYS_EXECUTE(SYS_INPUT_MODE_READ));
 	syscall_lookup.push_back(MAKE_SYS_EXECUTE(SYS_INPUT_MODE_WRITE));
-	syscall_lookup.push_back(MAKE_SYS_EXECUTE(SYS_INPUT_TO_STRUCT));
-
-	syscall_lookup.push_back(MAKE_SYS_EXECUTE(SYS_SET_CONSOLE_CURSOR));
-	syscall_lookup.push_back(MAKE_SYS_EXECUTE(SYS_GET_CONSOLE_CURSOR));
 #pragma endregion
 }
 
@@ -1029,15 +607,13 @@ bool VMCore::typed_MATH(varible* params)
 	varible val1 = 0, val2 = 0;
 
 	uint8_t math_mode = safe_cast<uint8_t>(params[0]);
-	//uint32_t math_mode = makeUint(params[0], immediate, arg_size);
 
-	// Initialize random engine with a device
 
 
 	if (math_mode != mmINC && math_mode != mmDEC)
 		val2 = typed_pop();
 	val1 = typed_pop();
-	//val1 = getUintVar(); // First operand
+
 	varible result = 0;
 	varible one = BaseValue::makeValue(vt_uint32_t, 1);
 
@@ -1048,9 +624,7 @@ bool VMCore::typed_MATH(varible* params)
 	case mmDEC: result = BaseValue::computeNumbers(val1, one, BaseValue::SubOperation{}); break;
 	case mmMUL: result = BaseValue::computeNumbers(val1, val2, BaseValue::MulOperation{}); break;
 	case mmDIV: result = BaseValue::computeNumbers(val1, val2, BaseValue::DivOperation{}); break;
-		//case mmPOW: result = pow(val1, val2); break;
-		//case mmROOT: result = pow(val1, 1.0 / val2); break;
-		//case mmSQRT: result = sqrt(val1); break;
+
 	case mmRAND: result = BaseValue::computeNumbers(val1, val2, BaseValue::RNDOperation{}); break;
 	default:
 		DIE << "Math mode with index " << HEX(math_mode) << " does not exist!";
@@ -1082,25 +656,7 @@ bool VMCore::typed_DEC(varible* params)
 	typed_setVar(var, result);
 	return true;
 }
-//bool VMCore::typed_AND(varible* params)
-//{
-//	varible val2 = typed_pop();
-//	varible val1 = typed_pop();
-//
-//	varible result = And(val1, val2);
-//	typed_push(result);
-//	return true;
-//}
-//
-//bool VMCore::typed_OR(varible* params)
-//{
-//	varible val2 = typed_pop();
-//	varible val1 = typed_pop();
-//
-//	varible result = Or(val1, val2);
-//	typed_push(result);
-//	return true;
-//}
+
 
 
 
@@ -1240,378 +796,28 @@ bool VMCore::typed_EXIT(varible* params)
 	return true;
 }
 #pragma endregion
-#pragma region Instructions
-void VMCore::PUSH(uint32_t* params, bool immediate, uint8_t arg_size)
-{
-	push(params[0], immediate, arg_size);
-}
-void VMCore::POP(uint32_t* params, bool immediate, uint8_t arg_size)
-{
-	pop();
-}
-void VMCore::DUP(uint32_t* params, bool immediate, uint8_t arg_size)
-{
-	uint32_t index = instance.sp - (params[0]+1);
 
-	if (index < 0 || params[0] + 1 > instance.sp)
-	{
-		DIE << "Nothing on the stack to duplicate at the index " << NUM(index) << "! At program index " << NUM(instance.ProgramIndex);
-	}
 
-	uint8_t type = instance.stack_type.at(index);
-	bool prevImmediate = (type & 0b10000000) >> 7;
-	uint8_t prevArg_size = type & 0b01111111;
 
-	uint32_t value = instance.stack.at(index);
 
-	push(value, prevImmediate, prevArg_size);
-}
-void VMCore::MATH(uint32_t* params, bool immediate, uint8_t arg_size)
-{
-	uint32_t val1 = 0,val2 = 0;
-	
-	uint32_t math_mode = makeUint(params[0], immediate, arg_size);
 
-	// Initialize random engine with a device
-	static std::random_device rd;
-	static std::mt19937 gen(rd());  // Mersenne Twister engine for randomness
 
-	if (math_mode != mmINC && math_mode != mmDEC)
-		val2 = getUintVar(); // Second operand
-	val1 = getUintVar(); // First operand
-	uint32_t result = 0;
 
-	switch (math_mode) {
-		case mmADD: result = val1 + val2; break;
-		case mmSUB: result = val1 - val2; break;
-		case mmINC: result = val1 + 1; break;
-		case mmDEC: result = val1 - 1; break;
-		case mmMUL: result = val1 * val2; break;
-		case mmDIV: result = val1 / val2; break;
-		//case mmPOW: result = pow(val1, val2); break;
-		//case mmROOT: result = pow(val1, 1.0 / val2); break;
-		//case mmSQRT: result = sqrt(val1); break;
-		case mmRAND:
-		{
-			std::uniform_int_distribution<> distrib(val1, val2);
 
-			// Generate a random number between min and max
-			result = distrib(gen);
-			break;
-		}
-		default:
-			DIE << "Math mode with index " << HEX(math_mode) << " does not exist!";
-	}
-	push(result);
-}
-void VMCore::AND(uint32_t* params, bool immediate, uint8_t arg_size)
-{
-	auto val2 = getUintVar();
-	auto val1 = getUintVar();
-	push(val1 & val2);
-}
-void VMCore::OR(uint32_t* params, bool immediate, uint8_t arg_size)
-{
-	auto val1 = getUintVar();
-	auto val2 = getUintVar();
-	push(val1 | val2);
-}
-void VMCore::NOT(uint32_t* params, bool immediate, uint8_t arg_size)
-{
-	auto val1 = getUintVar();
-	if (val1 == iFALSE) push(iTRUE);
-	else if (val1 == iTRUE) push(iFALSE);
-	else DIE << "Stack value expected a bool (0x00 or 0x01) but got " << HEX(val1) << "instead!";
-}
-void VMCore::COMP(uint32_t* params, bool immediate, uint8_t arg_size)
-{
-	uint32_t compare_mode = makeUint(params[0], immediate, arg_size);
-	auto val2 = getUintVar(); // Second operand
-	auto val1 = getUintVar(); // First operand
-	bool result = false;
-	switch (compare_mode) {
-		case cmGT: result = (val1 > val2); break;
-		case cmGTE: result = (val1 >= val2); break;
-		case cmLT: result = (val1 < val2); break;
-		case cmLTE: result = (val1 <= val2); break;
-		case cmEQ: result = (val1 == val2); break;
-		case cmNEQ: result = (val1 != val2); break;
-		default:
-			DIE << "Compare mode with index " << HEX(compare_mode) << " does not exist!";
-	}
-	if (result)
-		push(iTRUE);
-	else
-		push(iFALSE);
-}
-void VMCore::JUMP(uint32_t* params, bool immediate, uint8_t arg_size)
-{
-	Jump(params[0], immediate);
-}
-void VMCore::JUMP_IF(uint32_t* params, bool immediate, uint8_t arg_size)
-{
-	if (getUintVar() == iTRUE)
-	{
-		Jump(params[0], immediate);
-	}
-}
-void VMCore::CALL(uint32_t* params, bool immediate, uint8_t arg_size)
-{
-	//Call(params[0], immediate);
-}
-void VMCore::CALL_IF(uint32_t* params, bool immediate, uint8_t arg_size)
-{
-	if (getUintVar() == iTRUE)
-	{
-		//Call(params[0], immediate);
-	}
-}
-void VMCore::RET(uint32_t* params, bool immediate, uint8_t arg_size)
-{
-	Return();
-}
-void VMCore::SYSCALL(uint32_t* params, bool immediate, uint8_t arg_size)
-{
-	syscall(makeUint(params[0], immediate, arg_size));
-}
-void VMCore::EXIT(uint32_t* params, bool immediate, uint8_t arg_size)
-{
-	inputManager.setInputModePrinting(); //reset cursor mode
-	uint32_t exitCode = getUintVar();
-	printf("\n\nExit was called with code: %d\n", exitCode);
-	exit(exitCode);
-}
-void VMCore::SET_BUFFER(uint32_t* params, bool immediate, uint8_t arg_size)
-{
-	Value value = makeValue(params[0], immediate, arg_size);
-	instance.varible_buffer = std::vector<uint8_t>(value.data, value.data + value.length);
-}
-void VMCore::GET_BUFFER(uint32_t* params, bool immediate, uint8_t arg_size)
-{
-	if (immediate)
-		DIE << "Cant assign to immidate value!";
-
-	uint32_t length = instance.varible_buffer.size();
-	uint8_t* data = new uint8_t[length];
-	std::copy(instance.varible_buffer.begin(), instance.varible_buffer.end(), data);
-
-	uint32_t index = params[0];
-	instance.varibles[index] = data;
-	instance.meta[index] = length;
-}
-void VMCore::PUSH_BUFFER(uint32_t* params, bool immediate, uint8_t arg_size)
-{
-	Value value = makeValue(params[0], immediate, arg_size);
-	buffer_push(value);
-}
-
-void VMCore::BUFFER_UTIL(uint32_t* params, bool immediate, uint8_t arg_size)
-{
-	uint32_t buffer_mode = makeUint(params[0], immediate, arg_size);
-	switch (buffer_mode) {
-	case bmCLEAR: instance.varible_buffer.clear(); break;
-	case bmPOP_TO_STACK: push(buffer_pop()); break;
-	case bmPUSH_FROM_STACK: buffer_push(getVar()); break;
-	//case bmREMOVE_FROM_END: 
-	//{
-	//}
-	case bmFORMAT:
-	{
-		std::vector<uint8_t> &buffer = instance.varible_buffer;
-
-		std::vector<uint8_t> formatted_buffer;
-		formatted_buffer.reserve(buffer.size()); //atleast this small
-
-		size_t index = 0;
-		while(index < buffer.size())
-		{
-			size_t specifier_index = index;
-			//skip normal text
-			while(specifier_index < buffer.size() && instance.varible_buffer[specifier_index] != '%')
-				specifier_index++;
-
-			
-			if (specifier_index > index) //whats the point of copying noting
-				std::copy(buffer.begin()+index, buffer.begin()+specifier_index, std::back_inserter(formatted_buffer));
-
-			if (specifier_index >= buffer.size())
-				break; //no more format specifiers left, we're done
-
-			if (specifier_index+1 >= buffer.size())
-				DIE << "Incorrect format, '%' at the end!";
-
-			//we found % + a char for format, get value from stack and format it
-			char specifier = buffer[specifier_index+1];
-			Value stack_val = getVar();
-
-			std::string formatted;
-			switch (specifier)
-			{
-				case 'u': //unsigned int
-				{
-					uint32_t unsigned_val = binaryApi.CastToUint32(stack_val.data, stack_val.length);
-					formatted = std::to_string(unsigned_val);
-					break;
-				}
-				case 'd': //signed int
-				{
-					uint32_t unsigned_val = binaryApi.CastToUint32(stack_val.data, stack_val.length);
-					int32_t val = static_cast<int32_t>(unsigned_val);
-					formatted = std::to_string(val);
-					break;
-				}
-				case 's': //string
-				{
-					formatted.assign(stack_val.data, stack_val.data + stack_val.length);
-					break;
-				}
-				default:
-					DIE << "Unknown format specifier: %" << specifier;
-					break;
-			}
-
-			//append the formatted string
-			std::copy(formatted.begin(), formatted.end(), std::back_inserter(formatted_buffer));
-
-			//skip over % and format specifier like "%s"
-			index = specifier_index + 2;
-		}
-
-		instance.varible_buffer = std::move(formatted_buffer);
-		break;
-	}
-	default:
-		DIE << "Buffer mode with index " << HEX(buffer_mode) << " does not exist!";
-	}
-}
-
-void VMCore::SET_VAR(uint32_t* params, bool immediate, uint8_t arg_size)
-{
-	Value varible = getVar();
-	if (varible.immediate)
-		DIE << "Cant assign to immidate value!";
-	Value value = getVar();
-	setVar(varible, value);
-}
-void VMCore::SET_STRUCT(uint32_t* params, bool immediate, uint8_t arg_size)
-{
-	Value struct_instance = makeValue(params[0], false, arg_size);
-	uint32_t field_index = params[1];
-
-	uint32_t field_offset = 0;
-	uint8_t field_length = 0;
-
-	GetStructFieldDetails(struct_instance, field_index, &field_offset, &field_length);
-
-	uint32_t value = getUintVar();
-	uint8_t *data = binaryApi.CastFromUint32(value, field_length);
-	std::copy(data, data+field_length, struct_instance.data+field_offset);
-}
-
-void VMCore::GET_STRUCT(uint32_t* params, bool immediate, uint8_t arg_size)
-{
-	Value struct_instance = makeValue(params[0], false, arg_size);
-	uint32_t field_index = params[1];
-
-	uint32_t field_offset = 0;
-	uint8_t field_length = 0;
-
-	GetStructFieldDetails(struct_instance, field_index, &field_offset, &field_length);
-
-	uint32_t data = binaryApi.CastToUint32(&struct_instance.data[field_offset], field_length);
-	push(data);
-}
-void VMCore::CREATE_STRUCT(uint32_t* params, bool immediate, uint8_t arg_size)
-{
-	if (immediate)
-		DIE << "Cant assign value to immidate!";
-
-	uint32_t struct_definition_index = params[0];
-	uint32_t struct_instance_index = params[1];
-
-	checkVaribleIndex(struct_definition_index);
-	StructCache cache;
-	if (instance.structCache.find(struct_definition_index) != instance.structCache.end())
-		cache = instance.structCache[struct_definition_index];
-	else
-		cache = CacheStructDefinition(struct_definition_index);
-
-	freeVarible(struct_instance_index);
-
-	instance.meta[struct_instance_index] = cache.total_size;
-	instance.varibles[struct_instance_index] = new uint8_t[cache.total_size];
-
-	std::copy(cache.initial_data, cache.initial_data + cache.total_size, instance.varibles[struct_instance_index]);
-}
-void VMCore::CHECK_STACK(uint32_t* params, bool immediate, uint8_t arg_size)
-{
-	Value param_value = makeValue(params[0], immediate, arg_size);
-	if (StackEquals(param_value))
-		push(iTRUE);
-	else
-		push(iFALSE);
-}
-//void VMCore::GET_STRUCT(uint32_t* params, bool immediate, uint8_t arg_size)
-//{
-//	Value struc = makeValue(params[0], false, arg_size);
-//	uint32_t index = params[1];
-//	if (struc.length < 2)
-//		DIE << "Invalid struct passed";
-//	if (struc.data[0] != 0xFF) //simple struct indicator
-//		DIE << "Invalid struct passed";
-//
-//	const uint8_t offset = 2;
-//	uint8_t amount_of_fields = struc.data[1];
-//
-//	if (index > amount_of_fields)
-//		DIE << "Invalid struct passed";
-//
-//	if (struc.length < (amount_of_fields+offset))
-//		DIE << "Invalid struct passed";
-//
-//	size_t sum = 0;
-//	for (uint8_t i = 0; i < index; i++)
-//	{
-//		sum += struc.data[offset+i];
-//	}
-//
-//	if (struc.length < sum)
-//		DIE << "Invalid struct passed";
-//
-//	uint8_t length = struc.data[offset + index];
-//
-//	uint8_t *data = new uint8_t[length];
-//	for (size_t i = 0; i < length; i++)
-//	{
-//
-//	}
-//
-//	struc.data
-//}
 
 #pragma endregion
 #pragma region Syscalls
-void VMCore::SYS_PAUSE()
-{
-	uint32_t pause_ms = getUintVar();
-	std::this_thread::sleep_for(std::chrono::milliseconds(pause_ms));
-}
+
 void VMCore::SYS_CLEAR_CONSOLE()
 {
 	inputManager.clearScreen();
-	//DIE << "syscall SYS_CLEAR not implemented!";
+
 }
 
 void VMCore::SYS_READ()
 {
-	//varible buffer = typed_pop();
 	varible val = read_raw();
-	//typed_setVar(buffer, val);
 	typed_push(val);
-
-	//Value buffer = getVar(); //put address on stack that we can write to
-	//Value val = read_raw();
-	//setVar(buffer, val);
 }
 
 void VMCore::SYS_PRINT()
@@ -1629,8 +835,7 @@ void VMCore::SYS_PRINTLN()
 }
 void VMCore::SYS_DUMP()
 {
-	//if (!instance.hasSymbols)
-	//	DIE << "Cant dump varible because symbols are not included";
+
 
 	varible data = typed_pop();
 	varible symbol = new BaseValue(data->type_index, data->data, std::min(data->length, (size_t)4));
@@ -1648,56 +853,8 @@ void VMCore::SYS_DUMP()
 
 	delete symbol;
 }
-//void VMCore::SYS_TO_STRING_UNSIGNED()
-//{
-//	// Pop the buffer (where result will be stored)
-//	Value result_var = getVar();
-//	// Pop the number to convert
-//	Value number = getVar();
-//
-//	// Ensure number length is <= 4
-//	if (number.length > 4)
-//		DIE << "Number too bige!!1!";
-//
-//	// Convert the number to string
-//	uint32_t num = *reinterpret_cast<uint32_t*>(number.data);
-//	std::string result_str = std::to_string(num);
-//
-//	// Prepare the buffer
-//	std::vector<uint8_t> buffer(result_str.begin(), result_str.end());
-//	uint32_t length = buffer.size();
-//	uint8_t* data = new uint8_t[length];
-//	std::copy(buffer.begin(), buffer.end(), data);
-//
-//	// Store the result in `result_var`
-//	Value result(data, length, true);
-//	setVar(result_var, result);
-//}
-void VMCore::SYS_TO_STRING_SIGNED()
-{
-	// Pop the buffer (where result will be stored)
-	Value result_var = getVar();
-	// Pop the number to convert
-	Value number = getVar();
 
-	// Ensure number length is <= 4
-	if (number.length > 4)
-		DIE << "Number too bige!!1!";
 
-	// Convert the number to string
-	int32_t num = *reinterpret_cast<int32_t*>(number.data);
-	std::string result_str = std::to_string(num);
-
-	// Prepare the buffer
-	std::vector<uint8_t> buffer(result_str.begin(), result_str.end());
-	uint32_t length = buffer.size();
-	uint8_t* data = new uint8_t[length];
-	std::copy(buffer.begin(), buffer.end(), data);
-
-	// Store the result in `result_var`
-	Value result(data, length, true);
-	setVar(result_var, result);
-}
 void VMCore::SYS_PARSE()
 {
 	varible destination = typed_pop();
@@ -1706,52 +863,8 @@ void VMCore::SYS_PARSE()
 
 	auto idk = safe_cast<int>(destination);
 }
-//void VMCore::SYS_TO_NUMBER_UNSIGNED()
-//{
-//	// Pop the string to convert
-//	Value str_val = getVar();
-//
-//	// Extract the string from the Value
-//	std::string str(str_val.data, str_val.data + str_val.length);
-//
-//	// Convert to unsigned number
-//	try
-//	{
-//		unsigned long num = std::stoul(str);
-//		if (num > std::numeric_limits<uint32_t>::max())
-//			throw std::out_of_range("Number too large for uint32_t");
-//
-//		// Push the result as uint32_t
-//		push(static_cast<uint32_t>(num));
-//	}
-//	catch (const std::exception& e)
-//	{
-//		DIE << "Invalid unsigned integer string: " << str << ", error: " << e.what();
-//	}
-//}
-void VMCore::SYS_TO_NUMBER_SIGNED()
-{
-	// Pop the string to convert
-	Value str_val = getVar();
 
-	// Extract the string from the Value
-	std::string str(str_val.data, str_val.data + str_val.length);
 
-	// Convert to signed number
-	try
-	{
-		long num = std::stol(str);
-		if (num < std::numeric_limits<int32_t>::min() || num > std::numeric_limits<int32_t>::max())
-			throw std::out_of_range("Number out of range for int32_t");
-
-		// Push the result as int32_t
-		push(static_cast<int32_t>(num));
-	}
-	catch (const std::exception& e)
-	{
-		DIE << "Invalid signed integer string: " << str << ", error: " << e.what();
-	}
-}
 
 void VMCore::SYS_INPUT_MODE_READ()
 {
@@ -1763,59 +876,20 @@ void VMCore::SYS_INPUT_MODE_WRITE()
 	inputManager.setInputModePrinting();
 }
 
-void VMCore::SYS_INPUT_TO_STRUCT()
-{
-	Value struct_instance = getVar();
-	if (struct_instance.immediate)
-		DIE << "struct input can't be used with immediate value";
 
-	StructCache cache;
-	GetStructCache(struct_instance, &cache);
 
-	if (struct_instance.length < cache.total_size)
-		DIE << "Struct instance was too small";
 
-	for (size_t i = 0; i < cache.offsets.size(); i++)
-	{
-		uint32_t field_offset = cache.offsets[i];
-		uint8_t field_length = cache.lengths[i];
-		uint32_t scan_code = binaryApi.CastToUint32(&cache.initial_data[field_offset], field_length);
 
-		bool result = inputManager.getKeyDown(static_cast<int32_t>(scan_code));
-		uint8_t *data = binaryApi.CastFromUint32(result, field_length);
 
-		std::copy(data, data+field_length, struct_instance.data+field_offset);
-	}
-	fflush(stdin);
-}
-
-void VMCore::SYS_SET_CONSOLE_CURSOR()
-{
-	uint32_t y = getUintVar();
-	uint32_t x = getUintVar();
-	inputManager.setCursor(x, y);
-}
-
-void VMCore::SYS_GET_CONSOLE_CURSOR()
-{
-	int32_t y = 0;
-	int32_t x = 0;
-	inputManager.getCursor(&x, &y);
-	push(y);
-	push(x);
-}
 
 #pragma endregion
 #pragma region Syscall_helpers
-void VMCore::print_raw(Value val)
-{
-	print_raw(val.data, val.length);
-}
+
 void VMCore::print_raw(varible var)
 {
 	if (var->type_index == vt_string) //we have to somehow make it string
 	{
-		print_raw(var->data/*+offset*/, var->length);
+		print_raw(var->data, var->length);
 	}
 	else
 	{
@@ -1842,50 +916,9 @@ varible VMCore::read_raw() {
 
 
 	BaseValue* result = new BaseValue(vt_string, length);
-	//result->length = length;
-	//result->data = new uint8_t[length]; // or malloc if you want C-style
+
 	std::copy(buffer.begin(), buffer.end(), result->data);
 	return result;
-	//std::memcpy(result->data, str.data(), result->length);
 
-
-
-
-	//return makeValue<char*>();
-	//uint8_t* data = new uint8_t[length];
-	//std::copy(buffer.begin(), buffer.end(), data);
-	// Now `array` points to the raw data, and `length` contains the number of elements
-	//return Value(data, length, true);
 }
-//Value VMCore::read_raw() {
-//	std::vector<uint8_t> buffer;
-//	int value = getchar();
-//
-//	while(value >= ' ' && value <= '~')
-//	{
-//		buffer.push_back(static_cast<uint8_t>(value));
-//		value = getchar();
-//	}
-//
-//	uint32_t length = buffer.size();
-//	uint8_t* data = new uint8_t[length];
-//	std::copy(buffer.begin(), buffer.end(), data);
-//	// Now `array` points to the raw data, and `length` contains the number of elements
-//	return Value(data, length, true);
-//}
-//Value VMCore::read_raw() {
-//	std::vector<uint8_t> buffer;
-//
-//	 read bytes until enter is pressed
-//	while (true) {
-//		uint8_t byte = getchar();
-//		if (byte == '\n' || byte == EOF)
-//			break;
-//		buffer.push_back(byte);
-//	}
-//
-//	uint8_t* data = buffer.data();
-//	uint32_t length = buffer.size();
-//	return Value(data, length, true); //return imidate value
-//}
-//#pragma endregion
+

--- a/FriedVM/VMCore.h
+++ b/FriedVM/VMCore.h
@@ -12,10 +12,8 @@ public:
 	void Parse();
 	void Run(uint64_t start, uint64_t end);
 	bool typed_Peek_stack(varible* output, int offset = 0);
-	bool Peek_stack(uint32_t *pValue, int offset = 0);
 	bool typed_StackTruthy();
 	bool typed_StackEquals(varible param_value);
-	bool StackEquals(Value& param_value);
 private:
 	FBinary binaryApi;
 	InputManager inputManager;
@@ -35,26 +33,13 @@ private:
 
 	varible dup(varible value);
 
-	void freeVarible(uint32_t index);
-	uint32_t pop();
-	void push(uint32_t value, bool immediate = true, uint8_t arg_size = 4);
-	uint32_t buffer_pop();
-	void buffer_push(Value value);
+
 	void syscall(uint32_t index);
-	Value makeValue(uint32_t value, bool immediate, uint8_t arg_size);
-	void checkVaribleIndex(uint32_t index);
-	void GetStructCache(Value& struct_instance, StructCache* cache);
-	void GetStructFieldDetails(Value &struct_instance, uint32_t field_index, uint32_t *field_offset, uint8_t *field_length);
-	StructCache CacheStructDefinition(uint32_t index);
-	bool getStackType(bool* immediate, uint8_t* arg_size);
-	uint32_t makeUint(uint32_t value, bool immediate, uint8_t arg_size);
-	uint32_t getUintVar();
-	Value getVar();
-	void setVar(Value reference, Value newValue);
+
+
 	void typed_setVar(varible reference, varible newValue);
 	bool Compare(uint8_t compMode, varible var1, varible var2);
 	void Jump(varible offset);
-	void Jump(uint32_t offset, bool immidiate);
 	void Call(varible offset);
 	void Return();
 #pragma region typed_Instructions
@@ -72,8 +57,7 @@ private:
 	bool typed_INC(varible* params);
 	bool typed_DEC(varible* params);
 
-	//bool typed_AND(varible* params);
-	//bool typed_OR(varible* params);
+
 		 
 	bool typed_COMP(varible* params);
 	bool typed_CHECK_STACK(varible* params);
@@ -98,73 +82,24 @@ private:
 
 #pragma endregion
 #pragma region Instructions
-	void PUSH(uint32_t* params, bool immediate, uint8_t arg_size);
-	void POP(uint32_t* params, bool immediate, uint8_t arg_size);
-	void DUP(uint32_t* params, bool immediate, uint8_t arg_size);
 
-	void MATH(uint32_t* params, bool immediate, uint8_t arg_size);
 
-	void AND(uint32_t* params, bool immediate, uint8_t arg_size);
-	void OR(uint32_t* params, bool immediate, uint8_t arg_size);
-	void NOT(uint32_t* params, bool immediate, uint8_t arg_size);
-	
-	void COMP(uint32_t* params, bool immediate, uint8_t arg_size);
-	
-	void JUMP(uint32_t* params, bool immediate, uint8_t arg_size);
-	void JUMP_IF(uint32_t* params, bool immediate, uint8_t arg_size);
-
-	void CALL(uint32_t* params, bool immediate, uint8_t arg_size);
-	void CALL_IF(uint32_t* params, bool immediate, uint8_t arg_size);
-
-	void RET(uint32_t* params, bool immediate, uint8_t arg_size);
-	//
-	void SYSCALL(uint32_t* params, bool immediate, uint8_t arg_size);
-	
-	void EXIT(uint32_t* params, bool immediate, uint8_t arg_size);
-
-	void SET_BUFFER(uint32_t* params, bool immediate, uint8_t arg_size);
-	void GET_BUFFER(uint32_t* params, bool immediate, uint8_t arg_size);
-	void PUSH_BUFFER(uint32_t* params, bool immediate, uint8_t arg_size);
-	void BUFFER_UTIL(uint32_t* params, bool immediate, uint8_t arg_size);
-	void SET_VAR(uint32_t* params, bool immediate, uint8_t arg_size);
-	void SET_STRUCT(uint32_t* params, bool immediate, uint8_t arg_size);
-	void GET_STRUCT(uint32_t* params, bool immediate, uint8_t arg_size);
-	void CREATE_STRUCT(uint32_t* params, bool immediate, uint8_t arg_size);
-	
-	void CHECK_STACK(uint32_t* params, bool immediate, uint8_t arg_size);
-	//void GET_VAR(uint32_t* params, bool immediate, uint8_t arg_size);
-	//void POP_VAR(uint32_t* params, bool immediate, uint8_t arg_size);
-	//void PSH_VAR(uint32_t* params, bool immediate, uint8_t arg_size);
-	//void MOV_VAR(uint32_t* params, bool immediate, uint8_t arg_size);
-	//void DEL(uint32_t* params, bool immediate, uint8_t arg_size);
-	//void DEL(uint32_t* params, bool immediate, uint8_t arg_size);
-	//void DEL(uint32_t* params, bool immediate, uint8_t arg_size);
-	//void DEL(uint32_t* params, bool immediate, uint8_t arg_size);
 #pragma endregion
 
 #pragma region Syscalls
-	void SYS_PAUSE();
 	void SYS_CLEAR_CONSOLE();
 	void SYS_READ();
 	void SYS_PRINT();
 	void SYS_PRINTLN();
 	void SYS_DUMP();
 
-	//void SYS_TO_STRING_UNSIGNED();
-	void SYS_TO_STRING_SIGNED();
 	void SYS_PARSE();
-	//void SYS_TO_NUMBER_UNSIGNED();
-	void SYS_TO_NUMBER_SIGNED();
 
 	void SYS_INPUT_MODE_READ();
 	void SYS_INPUT_MODE_WRITE();
-	void SYS_INPUT_TO_STRUCT();
-
-	void SYS_SET_CONSOLE_CURSOR();
-	void SYS_GET_CONSOLE_CURSOR();
 #pragma endregion
 #pragma region Syscall_helpers
-	void print_raw(Value val);
+
 	void print_raw(varible var);
 	void print_raw(uint8_t* data, uint32_t length);
 	varible read_raw();


### PR DESCRIPTION
Cleaned up massive amounts of commented-out and unused code from before the typed system was implemented. Removed:

Hundreds of lines of commented-out code in VMCore.cpp Parse() method

All old instruction implementations using uint32_t* params signature

Unused syscalls and old Value system methods

Commented-out template code in BaseValue.h/cpp

Unused stack/variable management methods

Dead code in FBinary.cpp and InstructionSet.h

Unused includes and excessive blank lines

Files Changed:

FriedVM/VMCore.cpp - Major cleanup, removed ~1000+ lines

FriedVM/VMCore.h - Removed unused method declarations

FriedVM/Types/BaseValue.h - Removed commented template code

FriedVM/Types/BaseValue.cpp - Removed commented implementations

FriedVM/FBinary.cpp - Removed commented methods

FriedVM/InstructionSet.h - Removed commented definitions

Impact:

Significantly improved code readability

Reduced maintenance burden

Cleaner architecture focused on current typed system

No functional changes to runtime behavior